### PR TITLE
Fix shrinking windows when box-sizing == border-box

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,11 +11,15 @@
   
   // each scenario gets rendered in the preview
   const scenarios: Scenarios<YourComponent> = {
-    scenarioName: {
+    scenario1Name: {
       props: {},
       css: {}, // css styles applied to this scenario
-      size: { width: 100px, height: 100% } // restrict size available to the component
+      size: { width: "100px", height: "100%" } // restrict size available to the component
     },
+    scenario2Name: {
+      ...
+    },
+    ...
   };
   
   // default css styles are applied to all scenarios

--- a/src/lib/Resizeable.svelte
+++ b/src/lib/Resizeable.svelte
@@ -9,11 +9,18 @@
   onMount(() => {
     observer = new ResizeObserver((entries) => {
       entries.forEach((entry) => {
-        const { width: widthInPixel, height: heightInPixel } =
-          entry.contentRect;
-        if (widthInPixel === 0 && heightInPixel === 0) return;
-        width = `${widthInPixel.toFixed(0)}px`;
-        height = `${heightInPixel.toFixed(0)}px`;
+        let heightInPx: number, widthInPx: number;
+        const computedStyle = getComputedStyle(resizeable);
+        if (computedStyle.getPropertyValue("box-sizing") == "border-box") {
+          heightInPx = entry.borderBoxSize[0].blockSize;
+          widthInPx = entry.borderBoxSize[0].inlineSize;
+        } else {
+          heightInPx = entry.contentRect.height;
+          widthInPx = entry.contentRect.width;
+        }
+        if (widthInPx === 0 && heightInPx === 0) return;
+        width = `${widthInPx.toFixed(0)}px`;
+        height = `${heightInPx.toFixed(0)}px`;
       });
     });
     observer.observe(resizeable);


### PR DESCRIPTION
When box-sizing is set to border-box the window shrinked to zero in about one second.