### PR TITLE
[feature] Add support for non-JSON-ifyable properties

### DIFF
--- a/src/lib/ScenarioEditor.svelte
+++ b/src/lib/ScenarioEditor.svelte
@@ -1,6 +1,6 @@
 <script lang="ts">
   import { createEventDispatcher } from "svelte";
-
+  import { stringifyJSObj, unstringifyJSObj } from "$lib/StringifyJSObj.js";
   import type { ScenarioState } from "$lib/Preview.svelte";
 
   const dispatch = createEventDispatcher<{
@@ -10,11 +10,14 @@
   export let scenario: ScenarioState;
 
   function update(raw: string) {
+    let value: ScenarioState;
     try {
-      dispatch("edit", JSON.parse(raw));
+      value = unstringifyJSObj(raw) as ScenarioState;
+      stringifyJSObj(value); // ensure value is stringifyable again
     } catch {
-      // ignore
+      return; // ignore errors
     }
+    dispatch("edit", value);
   }
 </script>
 
@@ -22,8 +25,7 @@
   class="scenario"
   on:input={(e) => update(e.currentTarget.value)}
   wrap="off"
->
-  {JSON.stringify(scenario, null, 2)}
+  >{stringifyJSObj(scenario)}
 </textarea>
 
 <style>

--- a/src/lib/ScenarioEvents.svelte
+++ b/src/lib/ScenarioEvents.svelte
@@ -1,11 +1,12 @@
 <script lang="ts">
   import { cubicIn } from "svelte/easing";
+  import { stringifyJSObj } from "./StringifyJSObj.js";
 
   export let events: Event[];
 
   function summary(event: Event) {
     if (event instanceof CustomEvent)
-      return `${event.type}(${JSON.stringify(event.detail)})`;
+      return `${event.type}(${stringifyJSObj(event.detail, false)})`;
     else return `native(${event.type})`;
   }
 
@@ -14,11 +15,7 @@
     for (let prop in event) {
       eventObject[prop] = event[prop as keyof Event];
     }
-    return JSON.stringify(
-      eventObject,
-      (k, v) => (v === null ? undefined : v),
-      2,
-    );
+    return stringifyJSObj(eventObject);
   }
 
   function flash(

--- a/src/lib/StringifyJSObj.ts
+++ b/src/lib/StringifyJSObj.ts
@@ -1,0 +1,182 @@
+const relIndent = " ".repeat(2);
+
+export interface ConstructorFunc<T extends object> {
+  new (...params: unknown[]): T;
+}
+export type FactoryFunc<T extends object> = (...params: unknown[]) => T;
+export type DestructureFunc<T extends object> = (obj: T) => unknown[];
+
+type CustomTypePlugin<T extends object> = {
+  destructureFunc: DestructureFunc<T>;
+  factory?: FactoryFunc<T>;
+  name?: string;
+};
+const customTypePlugins = new Map<
+  ConstructorFunc<object>,
+  CustomTypePlugin<object>
+>();
+
+class AnnotatedToken {
+  constructor(
+    public text: string,
+    public type: "open" | "close" | "delimiter",
+  ) {}
+}
+type Token = string | AnnotatedToken;
+type TokenGenerator = Generator<Token>;
+
+function* makeAttrListTokens(obj: object): TokenGenerator {
+  for (const [attrName, attrValue] of Object.entries(obj!)) {
+    yield `"${attrName.toString()}": `;
+    yield* makeEvalableTokens(attrValue);
+    yield new AnnotatedToken(",", "delimiter");
+  }
+}
+
+function* makeListTokens(obj: unknown[]): TokenGenerator {
+  for (const item of obj) {
+    yield* makeEvalableTokens(item);
+    yield new AnnotatedToken(",", "delimiter");
+  }
+}
+
+function* makeEvalableTokens(obj: unknown): TokenGenerator {
+  if (obj === null) {
+    yield "null";
+  } else if (obj === undefined) {
+    yield "undefined";
+  } else if (typeof obj == "number" && isNaN(obj)) {
+    yield "NaN";
+  } else if (typeof obj == "function") {
+    yield "() => {}"; // has to be replaced by other mechanism
+  } else if (obj instanceof Array) {
+    yield new AnnotatedToken("[", "open");
+    yield* makeListTokens(obj);
+    yield new AnnotatedToken("]", "close");
+  } else if (typeof obj == "object") {
+    const constructor = (obj as object).constructor as ConstructorFunc<object>;
+    const plugin = customTypePlugins.get(constructor);
+    if (plugin === undefined) {
+      yield new AnnotatedToken("{", "open");
+      yield* makeAttrListTokens(obj);
+      yield new AnnotatedToken("}", "close");
+    } else {
+      if (plugin.name) yield plugin.name;
+      else if (plugin.factory) yield plugin.factory.name;
+      else yield `new ${constructor.name}`;
+      yield new AnnotatedToken("(", "open");
+      yield* makeListTokens(plugin.destructureFunc(obj));
+      yield new AnnotatedToken(")", "close");
+    }
+  } else {
+    // any other primitive type
+    yield JSON.stringify(obj);
+  }
+}
+
+function* iterateWithLookahead<T>(
+  iterable: Iterable<T>,
+  func: (element: T, lookahead: T | undefined) => Generator<T>,
+): Generator<T> {
+  let element: undefined | T = undefined;
+  for (const lookahead of iterable) {
+    if (element !== undefined) yield* func(element, lookahead);
+    element = lookahead;
+  }
+  if (element !== undefined) yield* func(element, undefined);
+}
+
+function* wrapTokens(tokenGen: TokenGenerator): TokenGenerator {
+  let curIndent = "\n";
+  yield* iterateWithLookahead(
+    tokenGen,
+    function* (curToken: Token, nextToken: Token | undefined) {
+      const curTokenType = (curToken as AnnotatedToken).type;
+      const nextTokenType = (nextToken as AnnotatedToken)?.type;
+      if (curTokenType == "open") {
+        yield curToken;
+        if (nextTokenType != "close") {
+          // keep empty structures on a single line
+          curIndent = curIndent + relIndent;
+          yield curIndent;
+        }
+      } else {
+        if (curTokenType != "delimiter" || nextTokenType != "close")
+          // output only non-trailing delimiter
+          yield curToken;
+        if (nextTokenType == "close")
+          curIndent = curIndent.slice(0, -relIndent.length);
+        if (curTokenType == "delimiter") yield curIndent;
+      }
+    },
+  );
+}
+
+/**
+ * converts a javascript object back into code that can be evaluated.
+ *
+ * limitations:
+ * - objects with prototypes requires plugins (see registerCustomType())
+ * - non displayable objects (i.e. functions or DOM elements) are not supported
+ *   yet
+ */
+export function stringifyJSObj(obj: unknown, multiline = true): string {
+  let tokenGen = makeEvalableTokens(obj);
+  if (multiline) tokenGen = wrapTokens(tokenGen);
+  return [...tokenGen]
+    .map((t) => (t instanceof AnnotatedToken ? t.text : t)) // remove annotations
+    .join("");
+}
+
+/**
+ * evaluates a string and returns the corresponding JS object.
+ *
+ * inverse of `stringifyJSObj`
+ */
+export function unstringifyJSObj(objStr: string): unknown {
+  const namespace = Array.from(customTypePlugins.entries()).map(
+    ([constr, plugin]) => [
+      plugin.name ?? plugin.factory?.name ?? constr.name,
+      plugin.factory ?? constr,
+    ],
+  );
+  const varNameList = namespace.map(([nm, _func]) => nm).join(",");
+  const valueCreator = eval(`({${varNameList}}) => (${objStr})`);
+  return valueCreator(Object.fromEntries(namespace));
+}
+
+/**
+ * Register Custom types that shall be renderable to an evalable string.
+ *
+ * @param constructorFunc This has to be either the constructor (i.e. <Date>)
+ *                        or a factory function (i.e. <dayjs>)
+ * @param destructureFunc This has to be a function that deconstructs an
+ *                        instance of the class into the parameters that were
+ *                        passed to the constructor.
+ * @param options         Sometimes an object shall not be created via
+ *                        constructor but via factory. In this case the factory
+ *                        func can be passed here.
+ *                        Furthermore optionally a different name can be
+ *                        specified.
+ */
+export function registerCustomType<T extends object>(
+  constructorFunc: ConstructorFunc<T>,
+  destructureFunc: DestructureFunc<T>,
+  options?: {
+    factory?: FactoryFunc<T>;
+    name?: string;
+  },
+) {
+  const name = options?.name ?? options?.factory?.name ?? constructorFunc.name;
+  if (customTypePlugins.has(constructorFunc))
+    throw new Error(`The Plugin "${name}" was registered twice`);
+  const custTypePlugin = (<object>{
+    destructureFunc,
+    ...options,
+  }) as CustomTypePlugin<object>;
+  customTypePlugins.set(constructorFunc, custTypePlugin);
+  return true;
+}
+
+// register plugins for standard prototypes:
+registerCustomType(Date, (obj) => [obj.toISOString()]);

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -1,4 +1,16 @@
 import Preview from "$lib/Preview.svelte";
+import {
+  registerCustomType,
+  type ConstructorFunc,
+  type DestructureFunc,
+  type FactoryFunc,
+} from "$lib/StringifyJSObj.js";
 
 export type { Scenarios } from "$lib/Preview.svelte";
 export default Preview;
+export {
+  registerCustomType,
+  type ConstructorFunc,
+  type DestructureFunc,
+  type FactoryFunc,
+};

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -2,13 +2,13 @@
   import Preview, { type Scenarios } from "$lib/Preview.svelte";
   import Mock from "./Mock.svelte";
 
-  const emits = ["click"];
+  const emits = ["click", "changeDateTime"];
   const scenarios: Scenarios<Mock> = {
     blue: {
-      props: { color: "blue" },
+      props: { color: "blue", dateTime: new Date("2000-01-01T02:00") },
     },
     red: {
-      props: { color: "red" },
+      props: { color: "red", dateTime: new Date("2099-12-31T23:59") },
     },
     green: {
       props: { color: "green" },

--- a/src/routes/Mock.svelte
+++ b/src/routes/Mock.svelte
@@ -2,11 +2,13 @@
   import { createEventDispatcher } from "svelte";
 
   export let color = "blue";
+  export let dateTime = new Date();
 
   let choices = ["blue", "red", "green"];
 
   const dispatch = createEventDispatcher<{
     click: string;
+    changeDateTime: Date;
   }>();
 </script>
 
@@ -17,6 +19,15 @@
     {/each}
   </select>
   <button on:click={() => dispatch("click", color)}> CLICK ME! </button>
+  <br />
+  <input
+    type="datetime-local"
+    value={dateTime.toISOString().slice(0, 16)}
+    on:change={(ev) => {
+      dateTime = new Date(ev.currentTarget?.value);
+      dispatch("changeDateTime", dateTime);
+    }}
+  />
   <slot />
 </div>
 


### PR DESCRIPTION
Until now properties that are not stringifyable as JSON and reparsable cannot be used. This not only includes complex objects but also: undefined, NaN.

Currently the only complex data type supported is Date. But via the provided plugininterface it is very easy to add additional types (also from code that is using this library)